### PR TITLE
Performance: faster compilation of GJ current and prevent jit re-compilation

### DIFF
--- a/models/cells/io.py
+++ b/models/cells/io.py
@@ -258,9 +258,9 @@ class IONeuron(bp.dyn.NeuDyn):
             (0.6 * bm.exp(-(vdiff * vdiff) / 2500.0) + 0.4) * vdiff * g_gj
         )
 
-        I_gj = bm.zeros_like(V_dend)
-        for i in range(len(gj_tgt)):
-            I_gj = I_gj.at[gj_tgt[i]].add(cx36_current_per_gj[i])
+        I_gj = bm.zeros_like(V_dend) \
+            .at[jax.numpy.array(gj_tgt)] \
+            .add(cx36_current_per_gj)
 
         return I_gj
 

--- a/models/network.py
+++ b/models/network.py
@@ -766,6 +766,8 @@ def run_simulation(duration=1000.0, dt=0.025, net_params=None, seed=42):
 
     runner = bp.DSRunner(net, monitors=monitors, dt=dt)
     runner.progress_bar = False
+    runner._fun_predict = bm.jit(runner._fun_predict)
     runner.run(duration)
+
 
     return runner


### PR DESCRIPTION
Change is very simple, but running the io_synchrony.py experiment is about 5x faster now

```diff
-        I_gj = bm.zeros_like(V_dend)
-        for i in range(len(gj_tgt)):
-            I_gj = I_gj.at[gj_tgt[i]].add(cx36_current_per_gj[i])
+        I_gj = bm.zeros_like(V_dend) \
+            .at[jax.numpy.array(gj_tgt)] \
+            .add(cx36_current_per_gj)
```

This is fine because (JAX documentation for `.at[]`):

> Unlike NumPy in-place operations such as :code:`x[idx] += y`, if multiple
> indices refer to the same location, all updates will be applied (NumPy would
> only apply the last update, rather than applying all updates.) The order
> in which conflicting updates are applied is implementation-defined and may be
> nondeterministic (e.g., due to concurrency on some hardware platforms).


jax.numpy.array cast is needed because of a bug in brainpy (https://github.com/brainpy/BrainPy/issues/743)

This could be optimized a little bit further by sorting the gj_tgt array and setting `indices_are_sorted=True`

Note that the actual simulation code is not much faster, still around 40k iterations/s on my laptop. Just the compute graph we send to the compiler is much simpler

Also includes a small monkey patch to the DSRunner class to prevent re-compilation for each run invokation. I think brainpy makes an attempt at preventing this with the jit=True argument to `for_loop` but in practice each invocation requires half a second of compilation, which slows down short simulations a lot. So a single line change to encapsulate the `for_loop` in jit as well:

```python
runner._fun_predict = bm.jit(runner._fun_predict)
```

Before:

![image](https://github.com/user-attachments/assets/cdb30dd6-5651-499b-afac-bdeb7656b09f)

After:

![image](https://github.com/user-attachments/assets/be71ce08-6ee9-4918-bba4-e244ac4d4d72)
